### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 AppsFlyer Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,8 +32,8 @@ POM_SCM_URL=http://bitbucket.org/appsflyer/appsflyer-android-sdk
 POM_SCM_CONNECTION=scm:hg:http://bitbucket.org/appsflyer/appsflyer-android-sdk
 POM_SCM_DEV_CONNECTION=scm:hg:https://bitbucket.org/appsflyer/appsflyer-android-sdk
 
-POM_LICENCE_NAME=Proprietary
-POM_LICENCE_URL=http://www.appsflyer.com
+POM_LICENCE_NAME=The MIT License (MIT)
+POM_LICENCE_URL=http://opensource.org/licenses/MIT
 POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=appsflyer


### PR DESCRIPTION
Because this repository currently does not have a license, use of this code is pretty restricted (see [GitHub's page on "No License"](https://choosealicense.com/no-permission/)).

Add an [MIT License](https://choosealicense.com/licenses/mit/) and update the POM license to explicitly allow commercial use, modification, distribution, and private use.  The MIT license is already used by the [AppsFlyer Segment iOS repository](https://github.com/AppsFlyerSDK/segment-appsflyer-ios/blob/master/LICENSE), as well as many other mobile Segment integrations.