### PR TITLE
Use androidx.test.ext:junit as testImplementation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,11 +38,13 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.test.ext:junit:1.1.5'
     implementation 'com.appsflyer:af-android-sdk:6.10.3'
+
     compileOnly 'com.android.installreferrer:installreferrer:2.1'
     compileOnly 'com.segment.analytics.android:analytics:4.+'
+
     testImplementation 'androidx.test:core:1.4.0'
+    testImplementation 'androidx.test.ext:junit:1.1.5'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.9.2'
     testImplementation 'com.android.installreferrer:installreferrer:2.1'


### PR DESCRIPTION
Currently it's being leaked as a runtime dependency for consumer apps - this PR keeps it as test dependency only.

Resolves https://github.com/AppsFlyerSDK/appsflyer-segment-android-plugin/issues/87


